### PR TITLE
Avoid conficts with WillPaginate

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,15 @@ authenticate :user, lambda {|user| user.admin? } do
 end
 ```
 
+#### WillPaginate
+If you use will_paginate then you will need to configure an initializer for Kaminari to avoid conflicts. Put this in `config/initializers/kaminari.rb`
+
+```ruby
+Kaminari.configure do |config|
+  config.page_method_name = :per_page_kaminari
+end
+```
+
 ## TODO
 
 - demo

--- a/app/controllers/notable_web/home_controller.rb
+++ b/app/controllers/notable_web/home_controller.rb
@@ -7,8 +7,10 @@ module NotableWeb
     def index
       where = Hash[ params.slice(:status, :note_type, :note, :user_id, :user_type).permit!.map{|k,v| ["notable_requests.#{k}", v] } ]
 
+      page_method_name = Kaminari.config.page_method_name
+
       # https://github.com/rails/rails/issues/9055
-      @requests = Notable::Request.order("notable_requests.id DESC").where(where).preload(:user).page(params[:page]).per(100)
+      @requests = Notable::Request.order("notable_requests.id DESC").where(where).preload(:user).public_send(page_method_name, params[:page]).per(100)
 
       if params[:action_name]
         @requests = @requests.where(action: params[:action_name])


### PR DESCRIPTION
If an application is using the `will_paginate` gem then loading the dashboard will result in a `undefined method`per’ for #<ActiveRecord::Relation []>` exception.

This pull request uses the Kaminari `page_method_name` which can be customized to avoid conflicts. Also added a note to the Readme.
